### PR TITLE
Fix bug with visitor

### DIFF
--- a/lib/ransack/adapters/mongoid/context.rb
+++ b/lib/ransack/adapters/mongoid/context.rb
@@ -32,7 +32,7 @@ module Ransack
           # when :decimal
           # else # :string
 
-          #name = '_id' if name == 'id'
+          name = '_id' if name == 'id'
 
           t = object.klass.fields[name].try(:type) || bind_pair_for(attr.name).first.fields[name].type
 

--- a/lib/ransack/adapters/mongoid/ransack/visitor.rb
+++ b/lib/ransack/adapters/mongoid/ransack/visitor.rb
@@ -5,7 +5,7 @@ module Ransack
       nodes.inject(&:and)
     end
 
-    def visit_and(object)
+    def visit_or(object)
       nodes = object.values.map { |o| accept(o) }.compact
       nodes.inject(&:or)
     end


### PR DESCRIPTION
In `Ransack::Visitor` the second  `visit_and` method was overwriting the true `visit_and` method.    It needs to be named to `visit_or`