### PR TITLE
Missing new method on AR::Base adapter

### DIFF
--- a/lib/ransack/adapters/mongoid/base.rb
+++ b/lib/ransack/adapters/mongoid/base.rb
@@ -85,6 +85,14 @@ module Ransack
             []
           end
 
+          # ransack_scope_skip_sanitize_args, by default, returns an empty array.
+          # i.e. use the sanitize_scope_args setting to determine if args should be converted.
+          # For overriding with a list of scopes which should be passed the args as-is.
+          #
+          def ransackable_scopes_skip_sanitize_args
+            []
+          end
+
           # imitating active record
 
           def joins_values *args


### PR DESCRIPTION
This copies over the default behavior (allowing overrides) from the ActiveRecord ransack adapter